### PR TITLE
Fix rst syntax error in README.rst

### DIFF
--- a/.github/workflows/python-publish.yml
+++ b/.github/workflows/python-publish.yml
@@ -27,7 +27,7 @@ jobs:
           pip install tox
       - name: Run tox
         run: |
-          tox    
+          tox
 
   deploy:
     if: startsWith(github.ref, 'refs/tags/v')
@@ -38,7 +38,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v2
         with:
-          python-version: "3.x"
+          python-version: "3.8.x"
       - name: Autobump version
         run: |
           # from refs/tags/v1.2.3 get 1.2.3
@@ -61,4 +61,5 @@ jobs:
           TWINE_PASSWORD: ${{ secrets.PYPI_PASSWORD }}
         run: |
           python setup.py sdist bdist_wheel
+          twine check dist/*
           twine upload dist/*

--- a/README.rst
+++ b/README.rst
@@ -36,7 +36,7 @@ Release workflow
 * Check with tox all tests and lintings: `tox`
 * Check with tox if the packaging works fine: `tox -e test_packaging`
 * Merge all your changes you would like to have in the release into the master branch
-* Check that all github actions for tests and linting do pass.
+* Check that all Github actions for tests and linting do pass (should be automatically enforced for PRs against master) 
 * Go to `BO4E-python`_ and click on *Create a new release* in the right sidebar
 * Write in the *Tag version* field and in the *Release title* your new version, i.e. `v0.0.6`
 * Add a describtion to the release

--- a/README.rst
+++ b/README.rst
@@ -35,7 +35,7 @@ Release workflow
 ================
 * Check with tox all tests and lintings: `tox`
 * Check with tox if the packaging works fine: `tox -e test_packaging`
-* Merge all your changes you would like to have in the release into the master branch.
+* Merge all your changes you would like to have in the release into the master branch
 * Check that all github actions for tests and linting do pass.
 * Go to `BO4E-python`_ and click on *Create a new release* in the right sidebar
 * Write in the *Tag version* field and in the *Release title* your new version, i.e. `v0.0.6`

--- a/README.rst
+++ b/README.rst
@@ -31,6 +31,21 @@ To enhance this BO4E implementation and contribute to this project check out the
    
 The created venv should be located somewhere around .tox/dev/Scripts.
 
+Release workflow
+================
+* Check with tox all tests and lintings: `tox`
+* Check with tox if the packaging works fine: `tox -e test_packaging`
+* Merge all your changes you would like to have in the release into the master branch.
+* Check that all github actions for tests and linting do pass.
+* Go to `BO4E-python`_ and click on *Create a new release* in the right sidebar
+* Write in the *Tag version* field and in the *Release title* your new version, i.e. `v0.0.6`
+* Add a describtion to the release.
+* Publish the release
+
+There is a github action which gets triggered by a release event.
+It will run all default tests with tox. If they pass, it will take the tag title to replace the version information in the *setup.cfg* file.
+After checking the package with `twize check` it will finally upload the new package release.
+
 Hochfrequenz
 ============
 `Hochfrequenz Unternehmensberatung GmbH`_ is a Grünwald (near Munich) based consulting company with offices in Berlin and Bremen.
@@ -45,3 +60,4 @@ Applications of talented developers are welcome at any time! Please consider vis
 .. _`career page`: https://www.hochfrequenz.de/karriere/stellenangebote/full-stack-entwickler/
 .. _`develop branch`: https://github.com/Hochfrequenz/BO4E-python/tree/develop
 .. _`tox`: https://pypi.org/project/tox/
+.. _`BO4E-python`: https://github.com/Hochfrequenz/BO4E-python

--- a/README.rst
+++ b/README.rst
@@ -44,7 +44,7 @@ Release workflow
 
 There is a github action which gets triggered by a release event.
 It will run all default tests with tox. If they pass, it will take the tag title to replace the version information in the *setup.cfg* file.
-After checking the package with `twize check` it will finally upload the new package release.
+After checking the package with `twine check` it will finally upload the new package release.
 
 Hochfrequenz
 ============

--- a/README.rst
+++ b/README.rst
@@ -39,7 +39,7 @@ Release workflow
 * Check that all github actions for tests and linting do pass.
 * Go to `BO4E-python`_ and click on *Create a new release* in the right sidebar
 * Write in the *Tag version* field and in the *Release title* your new version, i.e. `v0.0.6`
-* Add a describtion to the release.
+* Add a describtion to the release
 * Publish the release
 
 There is a github action which gets triggered by a release event.

--- a/README.rst
+++ b/README.rst
@@ -25,7 +25,8 @@ Feel free to open a Pull Request against the develop branch of this repository.
 Please provide unit tests if you contribute logic beyond bare bare business object definitions.
 
 To enhance this BO4E implementation and contribute to this project check out the `develop branch`_, install `tox`_ and set the virtual environment created by the command
-::
+.. code-block:: shell
+
    tox -e dev 
    
 The created venv should be located somewhere around .tox/dev/Scripts.

--- a/tox.ini
+++ b/tox.ini
@@ -51,6 +51,18 @@ commands =
     python -m pytest
 
 
+[testenv:test_packaging]
+basepython = python3.8
+skip_install = true
+deps =
+    setuptools
+    wheel
+    twine
+commands = 
+    python setup.py sdist bdist_wheel
+    twine check dist/*
+
+
 [flake8]
 ; can also be placed in .flake8, setup.cfg or in tox.ini
 exclude =


### PR DESCRIPTION
One rst syntax error stopped the release process.
To avoid this error in the future, I added a new tox environment to test the packaging process.
All steps to release a new bo4e package version are now described in the README.rst