### PR TITLE
Change construction for optional attributes

### DIFF
--- a/src/bo4e/com/adresse.py
+++ b/src/bo4e/com/adresse.py
@@ -18,7 +18,7 @@ class Adresse(COM, jsons.JsonSerializable):
     ort: str
 
     # optional attributes
-    postfach: str = attr.ib(init=False)
-    adresszusatz: str = attr.ib(init=False)
-    co_ergaenzung: str = attr.ib(init=False)
+    postfach: str = attr.ib(default=None)
+    adresszusatz: str = attr.ib(default=None)
+    co_ergaenzung: str = attr.ib(default=None)
     landescode: Landescode = attr.ib(default=Landescode.DE)


### PR DESCRIPTION
If you set an attribute to `init=False` you will get an issue in the deserialisation process. The json which is created from an object which does not contain an optional attribute won't contain it. But during the deserialisation process **all** potential attributes are required to be there. So we set all optional attributes per default to None.  