### PR TITLE
🔨 Add postfach as alternative to strasse

### DIFF
--- a/src/bo4e/com/adresse.py
+++ b/src/bo4e/com/adresse.py
@@ -5,6 +5,17 @@ from bo4e.com.com import COM
 from bo4e.enum.landescode import Landescode
 
 
+def strasse_xor_postfach(instance, attribute, value):
+    if (
+        instance.strasse is None or instance.hausnummer is None
+    ) and instance.postfach is None:
+        raise ValueError("Either strasse and hausnummer or postfach are required.")
+    elif (
+        instance.strasse is not None or instance.hausnummer is not None
+    ) and instance.postfach is not None:
+        raise ValueError("Only strasse and hausnummer or postfach are required.")
+
+
 @attr.s(auto_attribs=True, kw_only=True)
 class Adresse(COM, jsons.JsonSerializable):
     """
@@ -12,13 +23,13 @@ class Adresse(COM, jsons.JsonSerializable):
     """
 
     # required attributes
-    strasse: str
-    hausnummer: str
-    postleitzahl: str
-    ort: str
+    strasse: str = attr.ib(default=None, validator=strasse_xor_postfach)
+    hausnummer: str = attr.ib(default=None, validator=strasse_xor_postfach)
+    postfach: str = attr.ib(default=None, validator=strasse_xor_postfach)
+    postleitzahl: str = attr.ib(validator=attr.validators.instance_of(str))
+    ort: str = attr.ib(validator=attr.validators.instance_of(str))
 
     # optional attributes
-    postfach: str = attr.ib(default=None)
     adresszusatz: str = attr.ib(default=None)
     co_ergaenzung: str = attr.ib(default=None)
     landescode: Landescode = attr.ib(default=Landescode.DE)

--- a/src/bo4e/com/adresse.py
+++ b/src/bo4e/com/adresse.py
@@ -6,14 +6,13 @@ from bo4e.enum.landescode import Landescode
 
 
 def strasse_xor_postfach(instance, attribute, value):
-    if (
-        instance.strasse is None or instance.hausnummer is None
-    ) and instance.postfach is None:
-        raise ValueError("Either strasse and hausnummer or postfach are required.")
-    elif (
-        instance.strasse is not None or instance.hausnummer is not None
-    ) and instance.postfach is not None:
-        raise ValueError("Only strasse and hausnummer or postfach are required.")
+    if instance.strasse or instance.hausnummer:
+        if instance.postfach:
+            raise ValueError("Enter either strasse and hausnummer OR postfach.")
+        elif not instance.strasse:
+            raise ValueError("Missing strasse to hausnummer.")
+        elif not instance.hausnummer:
+            raise ValueError("Missing hausnummer to strasse.")
 
 
 @attr.s(auto_attribs=True, kw_only=True)
@@ -23,13 +22,13 @@ class Adresse(COM, jsons.JsonSerializable):
     """
 
     # required attributes
-    strasse: str = attr.ib(default=None, validator=strasse_xor_postfach)
-    hausnummer: str = attr.ib(default=None, validator=strasse_xor_postfach)
-    postfach: str = attr.ib(default=None, validator=strasse_xor_postfach)
     postleitzahl: str = attr.ib(validator=attr.validators.instance_of(str))
     ort: str = attr.ib(validator=attr.validators.instance_of(str))
 
     # optional attributes
+    strasse: str = attr.ib(default=None, validator=strasse_xor_postfach)
+    hausnummer: str = attr.ib(default=None, validator=strasse_xor_postfach)
+    postfach: str = attr.ib(default=None, validator=strasse_xor_postfach)
     adresszusatz: str = attr.ib(default=None)
     co_ergaenzung: str = attr.ib(default=None)
     landescode: Landescode = attr.ib(default=Landescode.DE)

--- a/tests/test_adresse.py
+++ b/tests/test_adresse.py
@@ -27,7 +27,18 @@ class TestAddress:
             jdkwargs={"ensure_ascii": False},
         )
 
+        assert "Nördliche Münchner Straße" in address_json
+        assert "27A" in address_json
+        assert "82031" in address_json
         assert "DE" in address_json
+
+        deserialized_address = Adresse.loads(address_json)
+
+        assert isinstance(deserialized_address, Adresse)
+        assert deserialized_address.strasse == "Nördliche Münchner Straße"
+        assert deserialized_address.hausnummer == "27A"
+        assert deserialized_address.postleitzahl == "82031"
+        assert deserialized_address.landescode == Landescode.DE
 
     def test_serialization_only_required_fields_postfach(self):
         address_test_data = {
@@ -99,14 +110,14 @@ class TestAddress:
         with open(
             datafiles / "test_data_adresse_missing_plz.json", encoding="utf-8"
         ) as json_file:
-            adress_test_data = json.load(json_file)
+            address_test_data = json.load(json_file)
 
         with pytest.raises(TypeError) as excinfo:
 
             _ = Adresse(
-                ort=adress_test_data["ort"],
-                strasse=adress_test_data["strasse"],
-                hausnummer=adress_test_data["hausnummer"],
+                ort=address_test_data["ort"],
+                strasse=address_test_data["strasse"],
+                hausnummer=address_test_data["hausnummer"],
             )
 
         assert "postleitzahl" in str(excinfo.value)

--- a/tests/test_adresse.py
+++ b/tests/test_adresse.py
@@ -7,7 +7,7 @@ from bo4e.enum.landescode import Landescode
 
 
 class TestAddress:
-    def test_serialization_only_required_fields(self):
+    def test_serialization_only_required_fields_strasse(self):
         with open(
             "./tests/test_data/test_data_adresse/test_data_adresse_only_required_fields.json",
             encoding="utf-8",
@@ -28,6 +28,34 @@ class TestAddress:
         )
 
         assert "DE" in address_json
+
+    def test_serialization_only_required_fields_postfach(self):
+        address_test_data = {
+            "postleitzahl": "82031",
+            "ort": "Grünwald",
+            "postfach": "10 64 38",
+        }
+
+        a = Adresse(
+            postleitzahl=address_test_data["postleitzahl"],
+            ort=address_test_data["ort"],
+            postfach=address_test_data["postfach"],
+        )
+
+        address_json = a.dumps(
+            strip_nulls=True,
+            key_transformer=jsons.KEY_TRANSFORMER_CAMELCASE,
+            jdkwargs={"ensure_ascii": False},
+        )
+
+        assert "10 64 38" in address_json
+        assert "82031" in address_json
+
+        deserialized_address = Adresse.loads(address_json)
+
+        assert isinstance(deserialized_address, Adresse)
+        assert deserialized_address.postfach == "10 64 38"
+        assert deserialized_address.postleitzahl == "82031"
 
     def test_serialization_only_required_fields_landescode_AT(self):
         with open(
@@ -82,3 +110,65 @@ class TestAddress:
             )
 
         assert "postleitzahl" in str(excinfo.value)
+
+    @pytest.mark.parametrize(
+        "address_test_data, expected",
+        [
+            pytest.param(
+                {
+                    "postleitzahl": "82031",
+                    "ort": "Grünwald",
+                    "strasse": None,
+                    "hausnummer": "27A",
+                    "postfach": None,
+                },
+                "Either",
+                id="Missing strasse",
+            ),
+            pytest.param(
+                {
+                    "postleitzahl": "82031",
+                    "ort": "Grünwald",
+                    "strasse": "Nördliche Münchner Straße",
+                    "hausnummer": None,
+                    "postfach": None,
+                },
+                "Either",
+                id="Missing hausnummer",
+            ),
+            pytest.param(
+                {
+                    "postleitzahl": "82031",
+                    "ort": "Grünwald",
+                    "strasse": None,
+                    "hausnummer": None,
+                    "postfach": None,
+                },
+                "Either",
+                id="Missing postfach",
+            ),
+            pytest.param(
+                {
+                    "postleitzahl": "82031",
+                    "ort": "Grünwald",
+                    "strasse": None,
+                    "hausnummer": "27A",
+                    "postfach": "10 64 38",
+                },
+                "Only",
+                id="Postfach and hausnummer",
+            ),
+        ],
+    )
+    def test_strasse_xor_postfach(self, address_test_data, expected):
+
+        with pytest.raises(ValueError) as excinfo:
+
+            _ = Adresse(
+                postleitzahl=address_test_data["postleitzahl"],
+                ort=address_test_data["ort"],
+                strasse=address_test_data["strasse"],
+                hausnummer=address_test_data["hausnummer"],
+                postfach=address_test_data["postfach"],
+            )
+        assert expected in str(excinfo.value)

--- a/tests/test_adresse.py
+++ b/tests/test_adresse.py
@@ -7,7 +7,11 @@ from bo4e.enum.landescode import Landescode
 
 
 class TestAddress:
-    def test_serialization_only_required_fields_strasse(self):
+    def test_serialization_strasse(self):
+        """
+        Test serialization with strasse und hausnummer
+        and default value of landescode
+        """
         with open(
             "./tests/test_data/test_data_adresse/test_data_adresse_only_required_fields.json",
             encoding="utf-8",
@@ -40,7 +44,8 @@ class TestAddress:
         assert deserialized_address.postleitzahl == "82031"
         assert deserialized_address.landescode == Landescode.DE
 
-    def test_serialization_only_required_fields_postfach(self):
+    def test_serialization_only_postfach(self):
+        """Test serialization with postfach"""
         address_test_data = {
             "postleitzahl": "82031",
             "ort": "Grünwald",
@@ -66,6 +71,33 @@ class TestAddress:
 
         assert isinstance(deserialized_address, Adresse)
         assert deserialized_address.postfach == "10 64 38"
+        assert deserialized_address.postleitzahl == "82031"
+
+    def test_serialization_only_required_fields(self):
+        """Test serialization with just postleitzahl und ort"""
+        address_test_data = {
+            "postleitzahl": "82031",
+            "ort": "Grünwald",
+        }
+
+        a = Adresse(
+            postleitzahl=address_test_data["postleitzahl"],
+            ort=address_test_data["ort"],
+        )
+
+        address_json = a.dumps(
+            strip_nulls=True,
+            key_transformer=jsons.KEY_TRANSFORMER_CAMELCASE,
+            jdkwargs={"ensure_ascii": False},
+        )
+
+        assert "Grünwald" in address_json
+        assert "82031" in address_json
+
+        deserialized_address = Adresse.loads(address_json)
+
+        assert isinstance(deserialized_address, Adresse)
+        assert deserialized_address.ort == "Grünwald"
         assert deserialized_address.postleitzahl == "82031"
 
     def test_serialization_only_required_fields_landescode_AT(self):
@@ -129,11 +161,22 @@ class TestAddress:
                 {
                     "postleitzahl": "82031",
                     "ort": "Grünwald",
-                    "strasse": None,
+                    "strasse": "Nördliche Münchner Straße",
+                    "hausnummer": None,
+                    "postfach": None,
+                },
+                "Missing hausnummer",
+                id="Missing hausnummer",
+            ),
+            pytest.param(
+                {
+                    "postleitzahl": "82031",
+                    "ort": "Grünwald",
+                    "strasse": "",
                     "hausnummer": "27A",
                     "postfach": None,
                 },
-                "Either",
+                "Missing strasse",
                 id="Missing strasse",
             ),
             pytest.param(
@@ -141,22 +184,11 @@ class TestAddress:
                     "postleitzahl": "82031",
                     "ort": "Grünwald",
                     "strasse": "Nördliche Münchner Straße",
-                    "hausnummer": None,
-                    "postfach": None,
+                    "hausnummer": "27A",
+                    "postfach": "10 64 38",
                 },
-                "Either",
-                id="Missing hausnummer",
-            ),
-            pytest.param(
-                {
-                    "postleitzahl": "82031",
-                    "ort": "Grünwald",
-                    "strasse": None,
-                    "hausnummer": None,
-                    "postfach": None,
-                },
-                "Either",
-                id="Missing postfach",
+                "hausnummer OR postfach",
+                id="Strasse, hausnummer and postfach",
             ),
             pytest.param(
                 {
@@ -166,7 +198,7 @@ class TestAddress:
                     "hausnummer": "27A",
                     "postfach": "10 64 38",
                 },
-                "Only",
+                "hausnummer OR postfach",
                 id="Postfach and hausnummer",
             ),
         ],

--- a/tests/test_data/test_data_adresse/test_data_adresse_only_required_fields.json
+++ b/tests/test_data/test_data_adresse/test_data_adresse_only_required_fields.json
@@ -1,6 +1,6 @@
 {
     "postleitzahl": "82031",
     "ort": "Grünwald",
-    "strasse": "Nördliche Müncher Straße",
+    "strasse": "Nördliche Münchner Straße",
     "hausnummer": "27A"
 }


### PR DESCRIPTION
Before strasse and hausnummer were required fields and postfach optional. Since postfach is an alternative address option to strasse and hausnummer this was changed to either strasse and hausnummer or postfach being a required address field.