### PR TITLE
Make attribute partneradresse in Geschaeftspartner optional

### DIFF
--- a/src/bo4e/bo/geschaeftspartner.py
+++ b/src/bo4e/bo/geschaeftspartner.py
@@ -25,7 +25,6 @@ class Geschaeftspartner(Geschaeftsobjekt):
     geschaeftspartnerrolle: List[Geschaeftspartnerrolle] = attr.ib(
         validator=attr.validators.instance_of(List)
     )
-    partneradresse: Adresse
 
     # optional attributes
     anrede: Anrede = attr.ib(default=None)
@@ -38,6 +37,7 @@ class Geschaeftspartner(Geschaeftsobjekt):
     glaeubiger_id: str = attr.ib(default=None)
     e_mail_adresse: str = attr.ib(default=None)
     website: str = attr.ib(default=None)
+    partneradresse: Adresse = attr.ib(default=None)
 
 
 class GeschaeftspartnerSchema(GeschaeftsobjektSchema):
@@ -49,7 +49,6 @@ class GeschaeftspartnerSchema(GeschaeftsobjektSchema):
     name1 = fields.Str()
     gewerbekennzeichnung = fields.Bool()
     geschaeftspartnerrolle = fields.List(EnumField(Geschaeftspartnerrolle))
-    partneradresse = fields.Nested(AdresseSchema)
 
     # optional attributes
     anrede = EnumField(Anrede, missing=None)
@@ -62,3 +61,4 @@ class GeschaeftspartnerSchema(GeschaeftsobjektSchema):
     glaeubiger_id = fields.Str(missing=None)
     e_mail_adresse = fields.Str(missing=None)
     website = fields.Str(missing=None)
+    partneradresse = fields.Nested(AdresseSchema, missing=None)

--- a/tests/test_geschaeftspartner.py
+++ b/tests/test_geschaeftspartner.py
@@ -61,7 +61,7 @@ class TestGeschaeftspartner:
         The BO4E standard does not yet define the cardinality of the partneradresse attribute.
         We will set this as an optional argument until the standard defines the cardinality.
 
-        This test checks whether the Geschaeftspartner can also be initialised without a partneradresse.
+        This test checks whether the Geschaeftspartner can also be initialized without a partneradresse.
         """
 
         gp = Geschaeftspartner(

--- a/tests/test_geschaeftspartner.py
+++ b/tests/test_geschaeftspartner.py
@@ -56,11 +56,47 @@ class TestGeschaeftspartner:
         assert gp_deserialised.bo_typ == gp.bo_typ
         assert type(gp_deserialised.partneradresse) == Adresse
 
+    def test_optional_attribute_partneradresse(self):
+        """
+        The BO4E standard does not yet define the cardinality of the partneradresse attribute.
+        We will set this as an optional argument until the standard defines the cardinality.
+
+        This test checks whether the Geschaeftspartner can also be initialised without a partneradresse.
+        """
+
+        gp = Geschaeftspartner(
+            anrede=Anrede.FRAU,
+            name1="von Sinnen",
+            name2="Helga",
+            name3=None,
+            gewerbekennzeichnung=True,
+            hrnummer="HRB 254466",
+            amtsgericht="Amtsgericht München",
+            kontaktweg=[Kontaktart.E_MAIL],
+            umsatzsteuer_id="DE267311963",
+            glaeubiger_id="DE98ZZZ09999999999",
+            e_mail_adresse="test@bo4e.de",
+            website="bo4e.de",
+            geschaeftspartnerrolle=[Geschaeftspartnerrolle.DIENSTLEISTER],
+        )
+
+        schema = GeschaeftspartnerSchema()
+        gp_json = schema.dumps(gp, ensure_ascii=False)
+
+        assert "Helga" in gp_json
+
+        gp_deserialised = schema.loads(gp_json)
+
+        assert gp_deserialised.bo_typ == gp.bo_typ
+        assert gp_deserialised.partneradresse is None
+
     def test_list_validation_of_geschaeftspartnerrolle(self):
         """
+        Tests that if the geschaeftspartnerrolle of Geschaeftspartner is not a list, an error is raised.
+
         The attribute geschaeftspartnerrolle of Geschaeftspartner must be a list type.
         Therefore the list validator checks the type of geschaeftspartnerrolle
-        during the initialization of Geschaeftspartner
+        during the initialization of Geschaeftspartner.
         """
 
         with pytest.raises(TypeError) as excinfo:

--- a/tests/test_geschaeftspartner.py
+++ b/tests/test_geschaeftspartner.py
@@ -82,12 +82,8 @@ class TestGeschaeftspartner:
 
         schema = GeschaeftspartnerSchema()
         gp_json = schema.dumps(gp, ensure_ascii=False)
-
-        assert "Helga" in gp_json
-
         gp_deserialised = schema.loads(gp_json)
 
-        assert gp_deserialised.bo_typ == gp.bo_typ
         assert gp_deserialised.partneradresse is None
 
     def test_list_validation_of_geschaeftspartnerrolle(self):

--- a/tests/test_geschaeftspartner.py
+++ b/tests/test_geschaeftspartner.py
@@ -58,8 +58,8 @@ class TestGeschaeftspartner:
 
     def test_optional_attribute_partneradresse(self):
         """
-        The BO4E standard does not yet define the cardinality of the partneradresse attribute.
-        We will set this as an optional argument until the standard defines the cardinality.
+        The BO4E standard does not yet define whether the partneradresse is mandatory or not.
+        We will set this as an optional argument until the standard is clear about it.
 
         This test checks whether the Geschaeftspartner can also be initialized without a partneradresse.
         """


### PR DESCRIPTION
The BO4E standard does not define if partneradresse is optional or required for Geschaeftspartner. So we define partneradresse as optional until the BO4E standard defines the cardinality.