### PR TITLE
Update year for copyright in LICENSE and docs/conf.py

### DIFF
--- a/LICENSE.rst
+++ b/LICENSE.rst
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2020 Hochfrequenz Unternehmensberatung GmbH
+Copyright (c) 2021 Hochfrequenz Unternehmensberatung GmbH
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -92,7 +92,7 @@ master_doc = "index"
 
 # General information about the project.
 project = u"bo4e"
-copyright = u"2020, Hochfrequenz GmbH"
+copyright = u"2021, Hochfrequenz GmbH"
 
 # The version info for the project you're documenting, acts as replacement for
 # |version| and |release|, also used in various other places throughout the


### PR DESCRIPTION
The year in the License was still 2020 in our BO4E documentation.
So this PR will fix this small issue