### PR TITLE
🔧 Move pytest configs from setup.cfg to pyproject.toml

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,3 +6,7 @@ build-backend = "setuptools.build_meta"
 line-length = 120
 
 [tool.setuptools_scm]
+
+[tool.pytest.ini_options]
+testpaths = "tests"
+markers = ["datafiles: load datafiles"]

--- a/setup.cfg
+++ b/setup.cfg
@@ -35,6 +35,3 @@ install_requires =
 where = src
 exclude =
     tests
-
-[tool:pytest]
-testpaths = tests


### PR DESCRIPTION
I also added a marker to remove the warnings during tests caused by datafiles