### PR TITLE
🎨 Fix UserWarnings caused by usage of dash-separated names

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -1,15 +1,15 @@
 [metadata]
 url = https://github.com/Hochfrequenz/BO4E-python
-project-urls =
+project_urls =
     Documentation = https://bo4e-python.readthedocs.io/en/latest/
     Code = https://github.com/Hochfrequenz/BO4E-python
     Issue tracker = https://github.com/Hochfrequenz/BO4E-python/issues
 license = mit
 author = Kevin Krechan
-author-email = kevin.krechan@hochfrequenz.de
+author_email = kevin.krechan@hochfrequenz.de
 description = Python Library that implements the BO4E Standard.
-long-description = file: README.rst
-long-description-content-type = text/x-rst; charset=UTF-8
+long_description = file: README.rst
+long_description_content_type = text/x-rst; charset=UTF-8
 platforms = any
 classifiers =
     Development Status :: 4 - Beta


### PR DESCRIPTION
I am not totally sure when we got the UserWarnings caused by the dashed-seperated variable names in the `setup.cfg` file.
My best guess is the test for packaging `tox -e test_packaging`.
At least in the output of this command, I am not able to find these UserWarnings anymore.

This PR is related to the issue https://github.com/Hochfrequenz/BO4E-python/issues/55