### PR TITLE
📝Document Enum Members by using `#:`; Remove 🔥 DocStrEnum approach that turned out to not work

### DIFF
--- a/docs/api/bo4e.enum.rst
+++ b/docs/api/bo4e.enum.rst
@@ -148,6 +148,14 @@ bo4e.enum.sparte module
    :undoc-members:
    :show-inheritance:
 
+bo4e.enum.strenum module
+------------------------
+
+.. automodule:: bo4e.enum.strenum
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
 bo4e.enum.tarifart module
 -------------------------
 

--- a/src/bo4e/enum/anrede.py
+++ b/src/bo4e/enum/anrede.py
@@ -1,14 +1,14 @@
 # pylint: disable=missing-module-docstring
-from bo4e.enum.strenum import DocumentedStrEnum
+from bo4e.enum.strenum import StrEnum
 
 
-class Anrede(DocumentedStrEnum):
+class Anrede(StrEnum):
     """
     Übersicht möglicher Anreden, z.B. eines Geschäftspartners.
     """
 
-    HERR = "HERR", "Herr"
-    FRAU = "FRAU", "Frau"
-    EHELEUTE = "EHELEUTE", "Eheleute"
-    FIRMA = "FIRMA", "Firma"
-    INDIVIDUELL = "INDIVIDUELL", 'Individuell (z.B. "Profx")'
+    HERR = "HERR"  #: "Herr
+    FRAU = "FRAU"  #: Frau
+    EHELEUTE = "EHELEUTE"  #: Eheleute
+    FIRMA = "FIRMA"  #: Firma
+    INDIVIDUELL = "INDIVIDUELL"  #: Individuell (z.B. "Profx")

--- a/src/bo4e/enum/strenum.py
+++ b/src/bo4e/enum/strenum.py
@@ -12,25 +12,3 @@ class StrEnum(str, Enum):
     """
 
     # see https://docs.python.org/3/library/enum.html?highlight=strenum#others
-
-
-# pylint: disable=too-few-public-methods
-class DocumentedStrEnum(StrEnum):
-    """
-    A StrEnum that has docstrings attached to its members.
-    Use it like this:
-    class MyDocumentedEnum(DocumentedStrEnum):
-    Foo = "Serialized Foo", "my good docstring of Foo"
-    Bar = "Serialized Bar", "bar is not foo (this is a docstring)"
-    Then wherever MyDocumentedEnum is used in BOs or COMs, the attribute will serialize as either "Serialized Foo"
-    or "Serialized Bar". And inspect.getdocs(MyDocumentedEnum.Foo) will return the respective docstring.
-    This is unittested.
-    """
-
-    # see https://stackoverflow.com/a/50473952/10009545
-    def __new__(cls, value, doc=None):
-        self = str.__new__(cls, value)  # calling super().__new__(value) here would fail
-        self._value_ = value
-        if doc is not None:
-            self.__doc__ = doc
-        return self

--- a/tests/test_enums.py
+++ b/tests/test_enums.py
@@ -4,9 +4,7 @@ from pathlib import Path
 from typing import List, Optional, TypeVar
 
 import pytest  # type:ignore[import]
-
 from bo4e.enum import anrede
-from bo4e.enum.anrede import Anrede
 from bo4e.enum.strenum import StrEnum
 
 
@@ -56,36 +54,3 @@ class TestEnums:
             assert docstring is not None
             assert not TestEnums.starts_with_whitespace_pattern.match(docstring)
             assert not TestEnums.ends_with_whitespace_pattern.match(docstring)
-
-    @pytest.mark.parametrize(
-        "enum_member, expected_docstring",
-        [
-            pytest.param(Anrede.HERR, "Herr"),
-            pytest.param(Anrede.INDIVIDUELL, 'Individuell (z.B. "Profx")'),
-        ],
-    )
-    def test_enum_member_docstrings_explicitly(self, enum_member: TEnum, expected_docstring: Optional[str]):
-        """
-        Test the docstrings of the enum members explicitly.
-        if the general approach (using DocumentedStrEnum) works for single members, it will also work for all enums,
-        which are constructed similarly.
-        """
-        assert inspect.getdoc(enum_member) == expected_docstring
-
-    def test_enum_members_are_all_documented(self):
-        """
-        The class docstrings are enforced using pylint but the docstrings of enum members are not covered by pylint.
-        """
-        all_enums = self._get_all_enum_classes()
-        for enum_class in all_enums:
-            class_docstring = TestEnums._get_class_doc(enum_class)
-            for enum_member in enum_class:
-                member_docstring = inspect.getdoc(enum_member)
-                assert (
-                    member_docstring != class_docstring
-                ), f"Docstring of Enum member {enum_member} must not be the same as the class docstring"
-                assert member_docstring is not None
-                assert member_docstring != ""
-                assert not TestEnums.starts_with_whitespace_pattern.match(member_docstring)
-                assert not TestEnums.ends_with_whitespace_pattern.match(member_docstring)
-            break  # proof this works just for the wip anrede

--- a/tox.ini
+++ b/tox.ini
@@ -54,6 +54,7 @@ deps =
     {[testenv:linting]deps}
     {[testenv:type_check]deps}
     {[testenv:coverage]deps}
+    {[testenv:docs]deps}
     black==21.5b2
     # Replace by any tag/version: https://github.com/psf/black/tags
     # and change the pre-commit-config.yaml accordingly


### PR DESCRIPTION
The last approaches to have documented enum members (not only classes) on read the docs resulted in a heuristic trial and error development process (see #75).

Now here's the next step to ultimate documentation truth on how to _really_ do it (aka "richtig statt falsch"):
- instead of adding docstrings somewhen at runtime (#75), add docs at "compile" time instead
- use comments with `#:` prefix as decribed here https://github.com/sphinx-doc/sphinx/issues/3255
- test the docs _locally_ (instead of waiting for readthedocs to update) by running tox - docs and checking the HTML output in `.tox/docs/tmp/html`

Works on my machine:
![grafik](https://user-images.githubusercontent.com/23094997/142036797-ba31bce5-b00e-4b9d-8875-8a3da02f1bca.png)
