### PR TITLE
💚 Use new publishing setup with trusted publishers

### DIFF
--- a/.github/workflows/python-publish.yml
+++ b/.github/workflows/python-publish.yml
@@ -33,7 +33,11 @@ jobs:
   build-n-publish:
     name: Build and publish Python 🐍 distributions 📦 to PyPI and TestPyPI
     runs-on: ubuntu-latest
+    # Specifying a GitHub environment, only there the pypi token is available!
     environment: release
+    permissions:
+      # IMPORTANT: this permission is mandatory for trusted publishing
+      id-token: write
     needs: tests
     steps:
       - uses: actions/checkout@v4
@@ -50,6 +54,3 @@ jobs:
       - name: Publish distribution 📦 to PyPI
         if: startsWith(github.ref, 'refs/tags/v')
         uses: pypa/gh-action-pypi-publish@release/v1
-        with:
-          user: __token__
-          password: ${{ secrets.PYPI_API_TOKEN }}


### PR DESCRIPTION
This PR introduces the new trusted publishers workflow

https://docs.pypi.org/trusted-publishers/

no pypi token is needed in the future 🪄