### PR TITLE
ci: bump bo4e CLI to v1.2.1 and update compatibility legend

### DIFF
--- a/.github/actions/setup-bo4e/action.yml
+++ b/.github/actions/setup-bo4e/action.yml
@@ -3,7 +3,7 @@ description: Download a pinned release of the bo4e CLI binary and put it on PATH
 
 inputs:
   version:
-    description: bo4e CLI release tag to install (e.g. v1.2.1).
+    description: bo4e CLI release tag to install.
     required: false
     default: v1.2.1
 

--- a/.github/actions/setup-bo4e/action.yml
+++ b/.github/actions/setup-bo4e/action.yml
@@ -3,9 +3,9 @@ description: Download a pinned release of the bo4e CLI binary and put it on PATH
 
 inputs:
   version:
-    description: bo4e CLI release tag to install (e.g. v1.2.0).
+    description: bo4e CLI release tag to install (e.g. v1.2.1).
     required: false
-    default: v1.2.0
+    default: v1.2.1
 
 runs:
   using: composite

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -38,7 +38,7 @@ You can also download the compatibility matrix as CSV file `here <_static/tables
    | ➖   | | :error-color:`Incompatible`                                                                     |
    |      | | Data model was removed in this version                                                          |
    +------+---------------------------------------------------------------------------------------------------+
-   | \-   | | Non\-existent                                                                                   |
+   | ∅    | | Non\-existent                                                                                   |
    |      | | Doesn't exist in this version i.e. it was removed before or will be added in future             |
    +------+---------------------------------------------------------------------------------------------------+
 


### PR DESCRIPTION
## Summary

- Pin the `setup-bo4e` action to `v1.2.1` (was `v1.2.0`). v1.2.1 ships [bo4e/BO4E-CLI#168](https://github.com/bo4e/BO4E-CLI/pull/168), which replaces the plain `-` glyph for "non-existent" cells with `∅` (U+2205 EMPTY SET) in emote-mode CSV output. The old `-` was getting parsed as a Sphinx bullet point when the matrix CSV was embedded in `docs/changelog.rst`.
- Update the compatibility-matrix legend in `docs/changelog.rst` to use `∅` instead of `\-`.
- The compatibility matrix CSV in `docs/_static/tables/compatibility_matrix.csv` is regenerated by `scripts/generate_docs_assets.py` on each docs build (`docs_latest.yml` / `python-publish.yml`), so it will pick up the new symbol automatically on the next run — no manual regeneration needed in this PR.

## Test plan

- [ ] CI docs build succeeds with `bo4e v1.2.1` and the regenerated `compatibility_matrix.csv` contains `∅` instead of `-`
- [ ] Rendered changelog page on RTD shows the `∅` cells as plain entries (no stray bullet points)