### PR TITLE
ci(setup-bo4e): retry the CLI download on transient network errors

### DIFF
--- a/.github/actions/setup-bo4e/action.yml
+++ b/.github/actions/setup-bo4e/action.yml
@@ -33,7 +33,13 @@ runs:
         dest="${RUNNER_TEMP}/bo4e"
         mkdir -p "${dest}"
         echo "Downloading ${url}"
-        curl --fail --silent --show-error --location --output "${RUNNER_TEMP}/${{ steps.asset.outputs.name }}" "${url}"
+        # --retry-all-errors is required on top of --retry: a bare --retry
+        # ignores connection-level failures, and the observed flake was
+        # "curl: (35) Recv failure: Connection reset by peer" against
+        # objects.githubusercontent.com, which failed the whole docs job.
+        curl --fail --silent --show-error --location \
+          --retry 3 --retry-delay 2 --retry-all-errors \
+          --output "${RUNNER_TEMP}/${{ steps.asset.outputs.name }}" "${url}"
         case "${{ steps.asset.outputs.name }}" in
           *.tar.xz) tar -xJf "${RUNNER_TEMP}/${{ steps.asset.outputs.name }}" --strip-components=1 -C "${dest}" ;;
           *.zip)    unzip -q  "${RUNNER_TEMP}/${{ steps.asset.outputs.name }}" -d "${dest}" ;;


### PR DESCRIPTION
## Why

The `Check Docs` job on #1142 failed with:

```
curl: (35) Recv failure: Connection reset by peer
```

while fetching the bo4e CLI tarball in the `Install bo4e CLI` step. Nothing was wrong with the change under test — a re-run of the identical commit went green.

A single TCP reset against `objects.githubusercontent.com` is enough to fail the whole docs build, and it can hit **any** PR at any time, since `.github/actions/setup-bo4e` is used by every workflow that builds docs.

## What

Adds `--retry 3 --retry-delay 2 --retry-all-errors` to the `curl` call.

`--retry-all-errors` is required *alongside* `--retry`: a bare `--retry` only covers transient HTTP responses and timeouts, not connection-level failures like the one observed.

## Verification

- `check-yaml` / `end-of-file-fixer` / `trailing-whitespace` pre-commit hooks pass on the changed file.
- The exact `curl` invocation was run against the pinned `v1.3.0` asset and downloaded it successfully (2023592 bytes).